### PR TITLE
Fix: Resolve ClassCastException in BlockDropItemEvent for Minecraft 1.21.7 compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,5 @@
-# Fabric and Paper
-- add picked-up items to vanilla statistics
-
 # Fabric
-- fix icon
+
 
 # Paper
-- improve event handling
+- resolve ClassCastException - by @Aathoss in [#41](https://github.com/btwonion/magnetic/pull/41)

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     `maven-publish`
 }
 
-val beta: Int? = property("beta").toString().toIntOrNull() // Pattern is '1.0.0-beta1-1.20.6-pre.2'
+val beta: Int? = property("beta").toString().toIntOrNull() // The pattern is '1.0.0-beta1-1.20.6-pre.2'
 val featureVersion = "${property("featureVersion")}${if (beta != null) "-beta$beta" else ""}"
 val mcVersion = property("mcVersion")!!.toString()
 val mcVersionName = property("versionName")!!.toString()
@@ -58,7 +58,7 @@ paperPluginYaml {
     foliaSupported = true
     apiVersion = "1.21"
 
-    dependencies.server("Veinminer", PaperPluginYaml.Load.BEFORE, false, true)
+    dependencies.server("Veinminer", PaperPluginYaml.Load.BEFORE, required = false, joinClasspath = true)
 }
 
 tasks {
@@ -97,7 +97,8 @@ publishMods {
         accessToken = providers.environmentVariable("MODRINTH_API_KEY")
         minecraftVersions.addAll(
             listOf(
-                "1.21.6"
+                "1.21.7",
+                "1.21.8"
             )
         )
     }

--- a/paper/gradle.properties
+++ b/paper/gradle.properties
@@ -1,2 +1,2 @@
-versionName=1.21.6
-mcVersion=1.21.6
+versionName=1.21.7
+mcVersion=1.21.7

--- a/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
@@ -8,6 +8,7 @@ import io.papermc.paper.event.block.PlayerShearBlockEvent
 import org.apache.commons.lang3.mutable.MutableInt
 import org.bukkit.Bukkit
 import org.bukkit.Statistic
+import org.bukkit.entity.Item
 import org.bukkit.event.Event
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockDropItemEvent
@@ -41,7 +42,13 @@ object Listeners {
 
     fun listenForBukkitEvents() {
         listen<BlockDropItemEvent> {
-            DropEvent(items as MutableList<ItemStack>, MutableInt(), player).also(Event::callEvent)
+            val itemStacks = items.map { it.itemStack }.toMutableList()
+            DropEvent(itemStacks, MutableInt(), player).also(Event::callEvent)
+
+            // Delete items that have been added to the inventory
+            items.removeIf { item ->
+                itemStacks.none { stack -> stack.isSimilar(item.itemStack) }
+            }
         }
 
         listen<BlockBreakEvent> {
@@ -53,16 +60,34 @@ object Listeners {
         listen<EntityDeathEvent> {
             val killer = entity.killer ?: return@listen
             val mutableInt = MutableInt(droppedExp)
-            DropEvent(drops as MutableList<ItemStack>, mutableInt, killer).also(Event::callEvent)
+            val itemStacks = drops.toMutableList()
+            DropEvent(itemStacks, mutableInt, killer).also(Event::callEvent)
             droppedExp = mutableInt.value
+
+            // Delete items that have been added to the inventory
+            drops.removeIf { item ->
+                itemStacks.none { stack -> stack.isSimilar(item) }
+            }
         }
 
         listen<PlayerShearBlockEvent> {
-            DropEvent(drops as MutableList<ItemStack>, MutableInt(), player).also(Event::callEvent)
+            val itemStacks = drops.toMutableList()
+            DropEvent(itemStacks, MutableInt(), player).also(Event::callEvent)
+
+            // Delete items that have been added to the inventory
+            drops.removeIf { item ->
+                itemStacks.none { stack -> stack.isSimilar(item) }
+            }
         }
 
         listen<PlayerShearEntityEvent> {
-            DropEvent(drops as MutableList<ItemStack>, MutableInt(), player).also(Event::callEvent)
+            val itemStacks = drops.toMutableList()
+            DropEvent(itemStacks, MutableInt(), player).also(Event::callEvent)
+
+            // Delete items that have been added to the inventory
+            drops.removeIf { item ->
+                itemStacks.none { stack -> stack.isSimilar(item) }
+            }
         }
 
         listen<PlayerFishEvent> {
@@ -76,8 +101,14 @@ object Listeners {
         if (Bukkit.getPluginManager().isPluginEnabled("Veinminer")) {
             listen<de.miraculixx.veinminer.VeinMinerEvent.VeinminerDropEvent> {
                 val mutableInt = MutableInt(exp)
-                DropEvent(items, mutableInt, player).also(Event::callEvent)
+                val itemStacks = items.toMutableList()
+                DropEvent(itemStacks, mutableInt, player).also(Event::callEvent)
                 exp = mutableInt.value
+
+                // Delete items that have been added to the inventory
+                items.removeIf { item ->
+                    itemStacks.none { stack -> stack.isSimilar(item) }
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem
The plugin was throwing a `ClassCastException` when using the Magnetic enchantment on Minecraft 1.21.7:


This prevented items from being properly added to the player's inventory when breaking blocks with the Magnetic enchantment.

## Solution
- Fixed the casting issue in `BlockDropItemEvent` by properly extracting `ItemStack` objects from `Item` entities using `items.map { it.itemStack }`
- Updated the item removal logic to correctly handle the conversion between `Item` entities and `ItemStack` objects
- Maintained compatibility with other events that already use `ItemStack` lists

## Changes
- Modified `paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt`
- Added proper type conversion for `BlockDropItemEvent.items`
- Fixed item removal logic to prevent duplicate items in the world

## Testing
- Verified compilation succeeds
- Tested on Minecraft 1.21.7 with Paper
- Magnetic enchantment now properly adds dropped items to player inventory

Closes #40 