### PR TITLE
Fix: Move config file to plugins/magnetic/magnetic.json directory

### DIFF
--- a/paper/src/main/kotlin/dev/nyon/magnetic/Main.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/Main.kt
@@ -16,7 +16,7 @@ class Main : JavaPlugin() {
 
     override fun onLoad() {
         INSTANCE = this
-        config(Bukkit.getPluginsFolder().toPath().resolve("magnetic.json"), 1, Config()) { _, _, _ -> null }
+        config(Bukkit.getPluginsFolder().toPath().resolve("Magnetic").resolve("magnetic.json"), 1, Config()) { _, _, _ -> null }
         internalConfig = loadConfig()
     }
 


### PR DESCRIPTION
## Problem
The configuration file was previously located at `/plugins/magnetic.json` (at the root of the plugins folder), which is not the standard location for plugin configuration files.

## Solution
Changed the config file path to be located at `/plugins/Magnetic/magnetic.json`, following the standard convention used by most Bukkit/Spigot plugins.

## Changes
- Modified `paper/src/main/kotlin/dev/nyon/magnetic/Main.kt` to change the config file location from `plugins/magnetic.json` to `plugins/magnetic/magnetic.json`.

## Testing
- Verified compilation succeeds.
- The config file is now created and loaded from the standard plugin directory structure.

This change makes the plugin more consistent with other Bukkit plugins and follows the established convention.