### PR TITLE
add needPermission option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,2 @@
-# Fabric
-- fix NullPointerException when trying to place a sponge in water
+# Paper
+- add option to require a player to have a permission ('magnetic.ability.use') to use the ability

--- a/paper/src/main/kotlin/dev/nyon/magnetic/Config.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/Config.kt
@@ -1,6 +1,10 @@
 package dev.nyon.magnetic
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 lateinit var config: Config
 
@@ -9,5 +13,19 @@ data class Config(
     var needEnchantment: Boolean = true,
     var needSneak: Boolean = false,
     var expAllowed: Boolean = true,
-    var itemsAllowed: Boolean = true
+    var itemsAllowed: Boolean = true,
+    var needPermission: Boolean = false
 )
+
+internal fun migrate(jsonElement: JsonElement, version: Int?): Config? {
+    val jsonObject = jsonElement.jsonObject
+    return when (version) {
+        1 -> Config(
+            needEnchantment = jsonObject["needEnchantment"]?.jsonPrimitive?.boolean ?: return null,
+            needSneak = jsonObject["needSneak"]?.jsonPrimitive?.boolean ?: return null,
+            expAllowed = jsonObject["expAllowed"]?.jsonPrimitive?.boolean ?: return null,
+            itemsAllowed = jsonObject["itemsAllowed"]?.jsonPrimitive?.boolean ?: return null
+        )
+        else -> null
+    }
+}

--- a/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
@@ -2,7 +2,7 @@
 
 package dev.nyon.magnetic
 
-import dev.nyon.magnetic.extensions.hasMagnetic
+import dev.nyon.magnetic.extensions.isAllowedToUseMagnetic
 import dev.nyon.magnetic.extensions.listen
 import io.papermc.paper.event.block.PlayerShearBlockEvent
 import org.apache.commons.lang3.mutable.MutableInt
@@ -19,11 +19,7 @@ object Listeners {
 
     @Suppress("unused")
     private val magneticListener = listen<DropEvent> {
-        if (config.needEnchantment && listOf(
-                player.inventory.itemInMainHand, player.inventory.itemInOffHand
-            ).none { it.hasMagnetic() }
-        ) return@listen
-        if (config.needSneak && !player.isSneaking) return@listen
+        if (!player.isAllowedToUseMagnetic()) return@listen
 
         if (config.itemsAllowed) {
             items.removeIf { item ->

--- a/paper/src/main/kotlin/dev/nyon/magnetic/Main.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/Main.kt
@@ -12,6 +12,7 @@ import kotlin.io.path.moveTo
 import dev.nyon.magnetic.config as internalConfig
 
 val magneticKey = NamespacedKey("magnetic", "magnetic")
+const val magneticPermission = "magnetic.ability.use"
 
 class Main : JavaPlugin() {
     companion object {
@@ -22,7 +23,7 @@ class Main : JavaPlugin() {
         INSTANCE = this
         val configPath = Bukkit.getPluginsFolder().toPath().resolve("magnetic/magnetic.json")
         moveConfigToNewPath(configPath)
-        config(configPath, 1, Config()) { _, _, _ -> null }
+        config(configPath, 2, Config()) { _, jsonElement, version -> migrate(jsonElement, version) }
         internalConfig = loadConfig()
     }
 

--- a/paper/src/main/kotlin/dev/nyon/magnetic/extensions/MagneticCheck.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/extensions/MagneticCheck.kt
@@ -1,6 +1,21 @@
 package dev.nyon.magnetic.extensions
 
+import dev.nyon.magnetic.config
 import dev.nyon.magnetic.magneticKey
+import dev.nyon.magnetic.magneticPermission
+import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 
 fun ItemStack.hasMagnetic(): Boolean = hasItemMeta() && itemMeta.enchants.any { it.key.key == magneticKey }
+
+fun Player.isAllowedToUseMagnetic(): Boolean {
+    if (config.needEnchantment && listOf(
+            inventory.itemInMainHand,
+            inventory.itemInOffHand
+        ).none { it.hasMagnetic() }
+    ) return false
+    if (config.needSneak && !isSneaking) return false
+    if (config.needPermission && !hasPermission(magneticPermission)) return false
+
+    return true
+}


### PR DESCRIPTION
Adds the option to require a player to have a permission ('magnetic.ability.use') to use the ability
Parent issue: #46 