### PR TITLE
add ignore-ranged-weapon option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,11 @@
 
 - add option to require a player to have a permission ('magnetic.ability.use') to use the ability
     - on Fabric the fabric-permissions-api has to be installed for this to work
+    - default: false
 - add option to ignore drops from entities when killed
     - you can use identifiers and tags to define these entities
     - the option is called 'ignoreKilledEntities' and can be configured via the config file or in-game in the config
       screen
+    - default: empty
+- add option to ignore drops produced by ranged weapons
+  - default: true

--- a/fabric/src/main/generated/data/magnetic/tags/item/ranged_weapons.json
+++ b/fabric/src/main/generated/data/magnetic/tags/item/ranged_weapons.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "minecraft:bow",
+    "minecraft:crossbow",
+    "minecraft:trident"
+  ]
+}

--- a/fabric/src/main/java/dev/nyon/magnetic/mixins/RegistryDataLoaderMixin.java
+++ b/fabric/src/main/java/dev/nyon/magnetic/mixins/RegistryDataLoaderMixin.java
@@ -3,7 +3,7 @@ package dev.nyon.magnetic.mixins;
 import com.google.gson.JsonElement;
 import com.mojang.serialization.Decoder;
 import dev.nyon.magnetic.config.ConfigKt;
-import dev.nyon.magnetic.datagen.MagneticEnchantmentGeneratorKt;
+import dev.nyon.magnetic.datagen.DataGeneratorKt;
 import net.minecraft.core.RegistrationInfo;
 import net.minecraft.core.WritableRegistry;
 import net.minecraft.resources.RegistryDataLoader;
@@ -34,6 +34,6 @@ public class RegistryDataLoaderMixin {
     ) {
         if (!ConfigKt.getConfig()
             .getNeedEnchantment() && registryKey.location()
-            .equals(MagneticEnchantmentGeneratorKt.getMagneticEnchantmentId())) ci.cancel();
+            .equals(DataGeneratorKt.getMagneticEnchantmentId())) ci.cancel();
     }
 }

--- a/fabric/src/main/java/dev/nyon/magnetic/mixins/entities/LivingEntityMixin.java
+++ b/fabric/src/main/java/dev/nyon/magnetic/mixins/entities/LivingEntityMixin.java
@@ -3,6 +3,8 @@ package dev.nyon.magnetic.mixins.entities;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Local;
 import dev.nyon.magnetic.DropEvent;
+import dev.nyon.magnetic.config.ConfigKt;
+import dev.nyon.magnetic.datagen.TagProviderKt;
 import dev.nyon.magnetic.extensions.MagneticCheckKt;
 import dev.nyon.magnetic.utils.MixinHelper;
 import net.minecraft.server.level.ServerLevel;
@@ -43,6 +45,7 @@ public abstract class LivingEntityMixin {
         Entity entity
     ) {
         if (MagneticCheckKt.isIgnored(instance.getType())) return original;
+        if (MagneticCheckKt.failsLongRangeCheck(instance.getLastDamageSource())) return original;
         if (!(entity instanceof ServerPlayer player)) return original;
 
         return MixinHelper.modifyExpressionValuePlayerExp(player, original);
@@ -56,6 +59,7 @@ public abstract class LivingEntityMixin {
         if (MagneticCheckKt.isIgnored(instance.getType())) return original;
         DamageSource source = params.contextMap()
             .getOptional(LootContextParams.DAMAGE_SOURCE);
+        if (MagneticCheckKt.failsLongRangeCheck(source)) return original;
         if (source == null || !(source.getEntity() instanceof ServerPlayer player)) return original;
 
         return item -> {

--- a/fabric/src/main/java/dev/nyon/magnetic/utils/MixinHelper.java
+++ b/fabric/src/main/java/dev/nyon/magnetic/utils/MixinHelper.java
@@ -60,6 +60,7 @@ public class MixinHelper {
         ItemStack item
     ) {
         LivingEntity lastAttacker = entity.getLastAttacker();
+        if (MagneticCheckKt.failsLongRangeCheck(entity.getLastDamageSource())) return true;
         if (!(lastAttacker instanceof ServerPlayer player)) return true;
         return entityWrapWithConditionPlayerItemSingle(player, item, entity);
     }
@@ -69,6 +70,7 @@ public class MixinHelper {
         List<ItemStack> items
     ) {
         if (MagneticCheckKt.isIgnored(entity.getType())) return items;
+        if (MagneticCheckKt.failsLongRangeCheck(entity.getLastDamageSource())) return items;
         LivingEntity lastAttacker = entity.getLastAttacker();
         if (!(lastAttacker instanceof ServerPlayer player)) return items;
 
@@ -85,6 +87,7 @@ public class MixinHelper {
         ItemStack item,
         Entity instance
     ) {
+        if (MagneticCheckKt.failsLongRangeCheck(source)) return true;
         Entity lastAttacker = source.getEntity();
         if (!(lastAttacker instanceof ServerPlayer player)) return true;
 
@@ -96,6 +99,7 @@ public class MixinHelper {
         List<ItemStack> items,
         Entity instance
     ) {
+        if (MagneticCheckKt.failsLongRangeCheck(source)) return items;
         if (MagneticCheckKt.isIgnored(instance.getType())) return items;
         Entity lastAttacker = source.getEntity();
         if (!(lastAttacker instanceof ServerPlayer player)) return items;

--- a/fabric/src/main/kotlin/dev/nyon/magnetic/config/Config.kt
+++ b/fabric/src/main/kotlin/dev/nyon/magnetic/config/Config.kt
@@ -31,7 +31,8 @@ data class Config(
     var expAllowed: Boolean = true,
     var itemsAllowed: Boolean = true,
     var needPermission: Boolean = false,
-    var ignoreKilledEntities: List<Identifier> = listOf()
+    var ignoreKilledEntities: List<Identifier> = listOf(),
+    var ignoreRangedWeapons: Boolean = true
 )
 
 private fun migrate(jsonElement: JsonElement, version: Int?): Config? {

--- a/fabric/src/main/kotlin/dev/nyon/magnetic/config/ConfigScreen.kt
+++ b/fabric/src/main/kotlin/dev/nyon/magnetic/config/ConfigScreen.kt
@@ -59,6 +59,14 @@ fun generateConfigScreen(parent: Screen? = null): Screen = YetAnotherConfigLib("
                 .initial("")
                 .build()
         )
+
+        val ignoreRangedWeapons by rootOptions.registering {
+            binding(true, { config.ignoreRangedWeapons }, { config.ignoreRangedWeapons = it })
+            controller = tickBox()
+            descriptionBuilder {
+                addDefaultText(1)
+            }
+        }
     }
 
     save { saveConfig(config) }

--- a/fabric/src/main/kotlin/dev/nyon/magnetic/datagen/DataGenerator.kt
+++ b/fabric/src/main/kotlin/dev/nyon/magnetic/datagen/DataGenerator.kt
@@ -1,0 +1,22 @@
+package dev.nyon.magnetic.datagen
+
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
+import net.minecraft.core.registries.Registries
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.tags.TagKey
+import net.minecraft.world.item.enchantment.Enchantment
+
+val magneticEffectId: TagKey<Enchantment> =
+    TagKey.create(Registries.ENCHANTMENT, ResourceLocation.fromNamespaceAndPath("magnetic", "auto_move"))
+val magneticEnchantmentId: ResourceLocation = ResourceLocation.fromNamespaceAndPath("magnetic", "magnetic")
+
+class DataGenerator : DataGeneratorEntrypoint {
+    override fun onInitializeDataGenerator(generator: FabricDataGenerator) {
+        val pack = generator.createPack()
+
+        pack.addProvider(::EnchantmentProvider)
+        pack.addProvider(::EnchantmentTagProvider)
+        pack.addProvider(::ItemTagProvider)
+    }
+}

--- a/fabric/src/main/kotlin/dev/nyon/magnetic/datagen/EnchantmentProvider.kt
+++ b/fabric/src/main/kotlin/dev/nyon/magnetic/datagen/EnchantmentProvider.kt
@@ -1,53 +1,19 @@
 package dev.nyon.magnetic.datagen
 
-import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint
-import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricDynamicRegistryProvider
-import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalItemTags
 import net.minecraft.core.HolderLookup
 import net.minecraft.core.registries.Registries
 import net.minecraft.resources.ResourceKey
 import net.minecraft.resources.ResourceLocation
-import net.minecraft.tags.EnchantmentTags
-import net.minecraft.tags.TagKey
 import net.minecraft.world.entity.EquipmentSlotGroup
 import net.minecraft.world.item.enchantment.Enchantment
 import net.minecraft.world.item.enchantment.Enchantment.EnchantmentDefinition
 import net.minecraft.world.item.enchantment.Enchantment.dynamicCost
 import java.util.concurrent.CompletableFuture
 
-val magneticEffectId: TagKey<Enchantment> =
-    TagKey.create(Registries.ENCHANTMENT, ResourceLocation.fromNamespaceAndPath("magnetic", "auto_move"))
-val magneticEnchantmentId: ResourceLocation = ResourceLocation.fromNamespaceAndPath("magnetic", "magnetic")
-
-class MagneticEnchantmentGenerator : DataGeneratorEntrypoint {
-    override fun onInitializeDataGenerator(generator: FabricDataGenerator) {
-        val pack = generator.createPack()
-
-        pack.addProvider(::EnchantmentProvider)
-        pack.addProvider(::MagneticEnchantmentTagProvider)
-    }
-}
-
-private class MagneticEnchantmentTagProvider(
-    output: FabricDataOutput, completableFuture: CompletableFuture<HolderLookup.Provider>
-) : FabricTagProvider<Enchantment>(output, Registries.ENCHANTMENT, completableFuture) {
-    override fun addTags(registries: HolderLookup.Provider) {
-        val enchantmentResourceKey = ResourceKey.create(Registries.ENCHANTMENT, magneticEnchantmentId)
-        listOf(
-            builder(magneticEffectId),
-            builder(EnchantmentTags.TRADEABLE),
-            builder(EnchantmentTags.IN_ENCHANTING_TABLE),
-            builder(EnchantmentTags.TREASURE)
-        ).forEach {
-            it.addOptional(enchantmentResourceKey)
-        }
-    }
-}
-
-private class EnchantmentProvider(
+class EnchantmentProvider(
     output: FabricDataOutput, registriesFuture: CompletableFuture<HolderLookup.Provider>
 ) : FabricDynamicRegistryProvider(output, registriesFuture) {
     override fun getName(): String {

--- a/fabric/src/main/kotlin/dev/nyon/magnetic/datagen/TagProvider.kt
+++ b/fabric/src/main/kotlin/dev/nyon/magnetic/datagen/TagProvider.kt
@@ -1,0 +1,44 @@
+package dev.nyon.magnetic.datagen
+
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider
+import net.minecraft.core.HolderLookup
+import net.minecraft.core.registries.Registries
+import net.minecraft.resources.ResourceKey
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.tags.EnchantmentTags
+import net.minecraft.tags.TagKey
+import net.minecraft.world.item.Item
+import net.minecraft.world.item.Items
+import net.minecraft.world.item.enchantment.Enchantment
+import java.util.concurrent.CompletableFuture
+
+val rangedWeaponLocation: ResourceLocation = ResourceLocation.fromNamespaceAndPath("magnetic", "ranged_weapons")
+val rangedWeaponKey: TagKey<Item> = TagKey.create(Registries.ITEM, rangedWeaponLocation)
+
+class EnchantmentTagProvider(
+    output: FabricDataOutput, completableFuture: CompletableFuture<HolderLookup.Provider>
+) : FabricTagProvider<Enchantment>(output, Registries.ENCHANTMENT, completableFuture) {
+    override fun addTags(registries: HolderLookup.Provider) {
+        val enchantmentResourceKey = ResourceKey.create(Registries.ENCHANTMENT, magneticEnchantmentId)
+        listOf(
+            builder(magneticEffectId),
+            builder(EnchantmentTags.TRADEABLE),
+            builder(EnchantmentTags.IN_ENCHANTING_TABLE),
+            builder(EnchantmentTags.TREASURE)
+        ).forEach {
+            it.addOptional(enchantmentResourceKey)
+        }
+    }
+}
+
+class ItemTagProvider(
+    output: FabricDataOutput, completableFuture: CompletableFuture<HolderLookup.Provider>
+) : FabricTagProvider.ItemTagProvider(output, completableFuture) {
+    override fun addTags(registries: HolderLookup.Provider) {
+        valueLookupBuilder(rangedWeaponKey)
+            .addOptional(Items.BOW)
+            .addOptional(Items.CROSSBOW)
+            .addOptional(Items.TRIDENT)
+    }
+}

--- a/fabric/src/main/kotlin/dev/nyon/magnetic/extensions/MagneticCheck.kt
+++ b/fabric/src/main/kotlin/dev/nyon/magnetic/extensions/MagneticCheck.kt
@@ -4,7 +4,9 @@ import dev.nyon.magnetic.config.config
 import dev.nyon.magnetic.config.ignoredEntities
 import dev.nyon.magnetic.config.loadIgnoredEntities
 import dev.nyon.magnetic.datagen.magneticEffectId
+import dev.nyon.magnetic.datagen.rangedWeaponKey
 import net.minecraft.server.level.ServerPlayer
+import net.minecraft.world.damagesource.DamageSource
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.item.enchantment.EnchantmentHelper
 
@@ -31,3 +33,8 @@ val EntityType<*>.isIgnored: Boolean
         }
         return ignoredEntities.contains(EntityType.getKey(this))
     }
+
+fun DamageSource?.failsLongRangeCheck(): Boolean {
+    if (this == null) return true
+    return config.ignoreRangedWeapons && weaponItem?.`is`(rangedWeaponKey) == true
+}

--- a/fabric/src/main/resources/assets/magnetic/lang/de_de.json
+++ b/fabric/src/main/resources/assets/magnetic/lang/de_de.json
@@ -11,5 +11,7 @@
     "yacl3.config.magnetic.category.general.root.option.itemsAllowed.description": "Entscheidet, ob Magnetic für auch für Item Drops funktionieren soll.",
     "yacl3.config.magnetic.category.general.root.option.ignoreKilledEntities": "Ignoriere Loot von Entities",
     "yacl3.config.magnetic.category.general.root.option.ignoreKilledEntities.description": "Angegebene Entities werden von Magnetic ignoriert und lassen ihren Loot wie gewöhnlich fallen. Es werden sowohl Tags, wie auch Ids von den Entities akzeptiert (Resource Location).",
+    "yacl3.config.magnetic.category.general.root.option.ignoreRangedWeapons": "Fernkampfwaffen ignorieren",
+    "yacl3.config.magnetic.category.general.root.option.ignoreRangedWeapons.description": "Loot, der vom Töten mit Fernkampfwaffen verursacht wird, wird von Magnetic ignoriert.",
     "enchantment.magnetic.magnetic.name": "Magnetic"
 }

--- a/fabric/src/main/resources/assets/magnetic/lang/en_us.json
+++ b/fabric/src/main/resources/assets/magnetic/lang/en_us.json
@@ -11,5 +11,7 @@
     "yacl3.config.magnetic.category.general.root.option.itemsAllowed.description": "Decides whether Magnetic should also work for item drops.",
     "yacl3.config.magnetic.category.general.root.option.ignoreKilledEntities": "Ignore killed entity drops",
     "yacl3.config.magnetic.category.general.root.option.ignoreKilledEntities.description": "The specified entities will not be affected by Magnetic. You can use both tags and entity ids (resource locations) to define which entities to ignore.",
+    "yacl3.config.magnetic.category.general.root.option.ignoreRangedWeapons": "Ignore ranged weapons",
+    "yacl3.config.magnetic.category.general.root.option.ignoreRangedWeapons.description": "Ignores drops that were produced via a kill with a long-ranged weapon (e.g. bow, crossbow, etc.).",
     "enchantment.magnetic.magnetic.name": "Magnetic"
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
     },
     "entrypoints": {
         "fabric-datagen": [
-            "dev.nyon.magnetic.datagen.MagneticEnchantmentGenerator"
+            "dev.nyon.magnetic.datagen.DataGenerator"
         ],
         "main": [
             {

--- a/paper/src/main/kotlin/dev/nyon/magnetic/Config.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/Config.kt
@@ -21,7 +21,8 @@ data class Config(
     var expAllowed: Boolean = true,
     var itemsAllowed: Boolean = true,
     var needPermission: Boolean = false,
-    var ignoreKilledEntities: List<Identifier> = listOf()
+    var ignoreKilledEntities: List<Identifier> = listOf(),
+    var ignoreRangedWeapons: Boolean = true
 )
 
 internal fun migrate(jsonElement: JsonElement, version: Int?): Config? {

--- a/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
@@ -2,6 +2,7 @@
 
 package dev.nyon.magnetic
 
+import dev.nyon.magnetic.extensions.failsLongRangeCheck
 import dev.nyon.magnetic.extensions.isAllowedToUseMagnetic
 import dev.nyon.magnetic.extensions.isIgnored
 import dev.nyon.magnetic.extensions.listen
@@ -55,6 +56,7 @@ object Listeners {
 
         listen<EntityDeathEvent> {
             if (entityType.isIgnored) return@listen
+            if (entity.lastDamageCause.failsLongRangeCheck()) return@listen
             val killer = entity.killer ?: return@listen
             val mutableInt = MutableInt(droppedExp)
             val itemStacks = drops.toMutableList()

--- a/paper/src/main/kotlin/dev/nyon/magnetic/extensions/MagneticCheck.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/extensions/MagneticCheck.kt
@@ -6,6 +6,7 @@ import dev.nyon.magnetic.magneticKey
 import dev.nyon.magnetic.magneticPermission
 import org.bukkit.entity.EntityType
 import org.bukkit.entity.Player
+import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.inventory.ItemStack
 
 fun ItemStack.hasMagnetic(): Boolean = hasItemMeta() && itemMeta.enchants.any { it.key.key == magneticKey }
@@ -26,3 +27,8 @@ val EntityType.isIgnored: Boolean
     get() {
         return ignoredEntities.contains(key)
     }
+
+fun EntityDamageEvent?.failsLongRangeCheck(): Boolean {
+    if (this == null) return true
+    return config.ignoreRangedWeapons && cause == EntityDamageEvent.DamageCause.PROJECTILE
+}


### PR DESCRIPTION
- add option to ignore drops produced by ranged weapons
- On Fabric there is a new tag called "ranged_weapons" that holds the weapons that will be ignored if the option is enabled
- On Paper every kill via a projectile will be ignored if the option is enabled