### PR TITLE
Handle break-chained drops on Paper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,3 +17,4 @@
 
 # Paper
 - fixed an issue, where the enchantment was created, even though the corresponding option was set to `false`
+- now also handle break-chained blocks like Sugar Cane, Bamboo, etc.

--- a/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
@@ -49,10 +49,18 @@ object Listeners {
     private val breakChainedBlocks = listOf(
         Material.BAMBOO,
         Material.CACTUS,
+        Material.CAVE_VINES,
+        Material.CAVE_VINES_PLANT,
         Material.CHORUS_FLOWER,
         Material.CHORUS_PLANT,
+        Material.KELP,
+        Material.KELP_PLANT,
         Material.SUGAR_CANE,
-        Material.SCAFFOLDING
+        Material.SCAFFOLDING,
+        Material.TWISTING_VINES,
+        Material.TWISTING_VINES_PLANT,
+        Material.WEEPING_VINES,
+        Material.WEEPING_VINES_PLANT
     )
     private val neededBlockFaces = BlockFace.entries.filter(BlockFace::isCartesian)
     fun listenForBukkitEvents() {

--- a/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
+++ b/paper/src/main/kotlin/dev/nyon/magnetic/Listeners.kt
@@ -34,7 +34,9 @@ object Listeners {
             items.removeIf { item ->
                 val copiedStack = item.clone()
                 if (player.inventory.addItem(item).isNotEmpty()) return@removeIf false
-                player.incrementStatistic(Statistic.PICKUP, copiedStack.type, copiedStack.amount)
+                if (copiedStack.amount != 0) player.incrementStatistic(
+                    Statistic.PICKUP, copiedStack.type, copiedStack.amount
+                )
                 true
             }
         }


### PR DESCRIPTION
Now handles break-chained blocks like Sugar Cane and Bamboo by scanning for connected blocks of the same materials and break them manually.